### PR TITLE
 Fixed website header, skip links, and linked to accessibility statem…

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -16,7 +16,6 @@
 </head>
 
 <body>
-  <m-universal-header></m-universal-header>
   <div role="navigation" class="skip-links" aria-label="Skip links">
     <div class="viewport-container">
       <ul>
@@ -25,10 +24,9 @@
       </ul>
     </div>
   </div>
-  <div>
-    <m-website-header variant="dark">
+  <m-universal-header></m-universal-header>
+    <m-website-header variant="dark" name="Journals with Article Processing Charge (APC) Agreements">
     </m-website-header>
-  </div>
   <main>
     <div class="viewport-container mt-5 mb-5" id="maincontent">
       <h1 class="mb-4">Journals with Article Processing Charge (APC) Agreements</h1>
@@ -90,7 +88,7 @@
           <h2>Contact Us</h2>
           <ul>
             <li><a href="mailto:lib-oa-pub@umich.edu">lib-oa-pub@umich.edu</a></li>
-            <li><a href="https://lib.umich.edu/about-us/about-library/accessibility">Accessibility</a></li>
+            <li><a href="https://docs.google.com/document/d/1R2MDA9c88eJlaf0YJdrvRkSERD6YLUViDKu1tfBL8hE/edit?tab=t.rcxk5559rhx">Accessibility</a></li>
           </ul>
         </section>
         <section>

--- a/html/index.html
+++ b/html/index.html
@@ -88,7 +88,7 @@
           <h2>Contact Us</h2>
           <ul>
             <li><a href="mailto:lib-oa-pub@umich.edu">lib-oa-pub@umich.edu</a></li>
-            <li><a href="https://docs.google.com/document/d/1R2MDA9c88eJlaf0YJdrvRkSERD6YLUViDKu1tfBL8hE/edit?tab=t.rcxk5559rhx">Accessibility</a></li>
+            <li><a href="https://docs.google.com/document/d/1R2MDA9c88eJlaf0YJdrvRkSERD6YLUViDKu1tfBL8hE/view">Accessibility</a></li>
           </ul>
         </section>
         <section>


### PR DESCRIPTION
This update contains the following:
- links the accessibility statement to the "Accessibility" item in the footer instead of the Library's general accessibility page
- adds a "name" attribute to the `<m-website-header>` component. This fixes the empty anchor issue in the header.
- moves the skip links above the `<m-universal-header>`