### PR TITLE
added 100 lengthMenu option

### DIFF
--- a/html/js/script.js
+++ b/html/js/script.js
@@ -213,7 +213,7 @@ $(document).ready(function () {
         },
         columns: columns,
         pageLength: 10,
-        lengthMenu: [5, 10, 25, 50],
+        lengthMenu: [5, 10, 25, 50, 100],
         order: [[0, 'asc']],
         autoWidth: false,
         responsive: true,


### PR DESCRIPTION
Added a "100" option to the `lengthMenu' to allow users to view 100 entries per page. This request came from Robyn on behalf Leena. The example provided mentioned "cell" as one term giving folks problems.